### PR TITLE
CMakeLists.txt: Disable MSVC warning from third_party

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,12 @@ function(cppdap_set_target_options target)
 
     # Disable specific, pedantic warnings
     if(MSVC)
-        target_compile_options(${target} PRIVATE "-D_CRT_SECURE_NO_WARNINGS")
+        target_compile_options(${target} PRIVATE
+            "-D_CRT_SECURE_NO_WARNINGS"
+
+            # Warnings from nlohmann/json headers.
+            "/wd4267" # 'argument': conversion from 'size_t' to 'int', possible loss of data
+        )
     endif()
 
     # Treat all warnings as errors


### PR DESCRIPTION
`nlohmann/json` raises a `size_t` to `int` MSVC warning in a public header that will fail the build if `CPPDAP_WARNINGS_AS_ERRORS` is enabled.
Given that this is not our code, the best we can do is to make an exception for this warning.