### PR TITLE
"body " field in  Response is an option field.

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -411,11 +411,12 @@ class Impl : public dap::Session {
       auto data = std::unique_ptr<uint8_t[]>(new uint8_t[typeinfo->size()]);
       typeinfo->construct(data.get());
 
+     //"body " field in  Response is an option field. 
       if (!d->field("body", [&](const dap::Deserializer* d) {
             return typeinfo->deserialize(d, data.get());
           })) {
-        handlers.error("Failed to deserialize request");
-        return;
+        //handlers.error("Failed to deserialize request");
+        //return;
       }
 
       handler(data.get(), nullptr);


### PR DESCRIPTION
"body " field in  Response is an option field. But in In file cppdap/src/session.cpp ,  It as an  obligatory field when has sucess field.
When i send an attach request to vscode.java.debug server ,   the dap server retrurn 
"{\"success\":true,\"request_seq\":1,\"command\":\"attach\",\"seq\":3,\"type\":\"response\"}"
It didn't has body field ,but success.