### PR TITLE
Fix the bug in Session::send method

### DIFF
--- a/include/dap/session.h
+++ b/include/dap/session.h
@@ -201,7 +201,8 @@ class Session {
   virtual void registerHandler(const TypeInfo* typeinfo,
                                const GenericResponseSentHandler& handler) = 0;
 
-  virtual bool send(const dap::TypeInfo* typeinfo,
+  virtual bool send(const dap::TypeInfo* requestTypeInfo,
+                    const dap::TypeInfo* responseTypeInfo,
                     const void* request,
                     const GenericResponseHandler& responseHandler) = 0;
 
@@ -251,9 +252,9 @@ template <typename T, typename>
 future<ResponseOrError<typename T::Response>> Session::send(const T& request) {
   using Response = typename T::Response;
   promise<ResponseOrError<Response>> promise;
-  const TypeInfo* typeinfo = TypeOf<T>::type();
-  auto sent =
-      send(typeinfo, &request, [=](const void* result, const Error* error) {
+  auto sent = send(
+      TypeOf<T>::type(), TypeOf<Response>::type(), &request,
+      [=](const void* result, const Error* error) {
         if (error != nullptr) {
           promise.set_value(ResponseOrError<Response>(*error));
         } else {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -411,11 +411,12 @@ class Impl : public dap::Session {
       auto data = std::unique_ptr<uint8_t[]>(new uint8_t[typeinfo->size()]);
       typeinfo->construct(data.get());
 
+     //"body " field in  Response is an option field. 
       if (!d->field("body", [&](const dap::Deserializer* d) {
             return typeinfo->deserialize(d, data.get());
           })) {
-        handlers.error("Failed to deserialize request");
-        return;
+        //handlers.error("Failed to deserialize request");
+        //return;
       }
 
       handler(data.get(), nullptr);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -80,19 +80,20 @@ class Impl : public dap::Session {
     });
   }
 
-  bool send(const dap::TypeInfo* typeinfo,
+  bool send(const dap::TypeInfo* requestTypeInfo,
+            const dap::TypeInfo* responseTypeInfo,
             const void* request,
             const GenericResponseHandler& responseHandler) override {
     int seq = nextSeq++;
 
-    handlers.put(seq, typeinfo, responseHandler);
+    handlers.put(seq, responseTypeInfo, responseHandler);
 
     dap::json::Serializer s;
     s.field("seq", dap::integer(seq));
     s.field("type", "request");
-    s.field("command", typeinfo->name());
+    s.field("command", requestTypeInfo->name());
     s.field("arguments", [&](dap::Serializer* s) {
-      return typeinfo->serialize(s, request);
+      return requestTypeInfo->serialize(s, request);
     });
     return send(s.dump());
   }
@@ -411,13 +412,11 @@ class Impl : public dap::Session {
       auto data = std::unique_ptr<uint8_t[]>(new uint8_t[typeinfo->size()]);
       typeinfo->construct(data.get());
 
-     //"body " field in  Response is an option field. 
-      if (!d->field("body", [&](const dap::Deserializer* d) {
-            return typeinfo->deserialize(d, data.get());
-          })) {
-        //handlers.error("Failed to deserialize request");
-        //return;
-      }
+      // "body" field in Response is an optional field.
+      d->field("body", [&](const dap::Deserializer* d) {
+        return typeinfo->deserialize(d, data.get());
+      });
+   
 
       handler(data.get(), nullptr);
       typeinfo->destruct(data.get());


### PR DESCRIPTION
1.We need the response typeinfo to deserialize the response type.
Why the testcase didn't find out the bug. Because the testquest type and typeresponse type hase the same field name and same filed type.Their typeinfo is the same ,so it didn't find the bug.
2.add another testcase to test the sessiong::send metho.
3.   "body" field in Response is an optional field. So i change the code.