### PR TITLE
CMake: Make the cppdap target's include directory public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ function(cppdap_set_target_options target)
     #     target_compile_options(${target} PRIVATE "-Wl,--no-undefined")
     # endif()
 
-    target_include_directories(${target} PRIVATE ${CPPDAP_INCLUDE_DIR})
+    target_include_directories(${target} PUBLIC ${CPPDAP_INCLUDE_DIR})
 endfunction(cppdap_set_target_options)
 
 ###########################################################

--- a/README.md
+++ b/README.md
@@ -62,12 +62,6 @@ This will define the `cppdap` library target, which you can pass to `target_link
 target_link_libraries(<target> cppdap) # replace <target> with the name of your project's target
 ```
 
-You will also want to add the `cppdap` public headers to your project's include search paths so you can `#include` the `cppdap` headers:
-
-```cmake
-target_include_directories($<target> PRIVATE "${CPPDAP_DIR}/include") # replace <target> with the name of your project's target
-```
-
 You may also wish to specify your own paths to the third party libraries used by `cppdap`.
 You can do this by setting any of the following variables before the call to `add_subdirectory()`:
 


### PR DESCRIPTION
Avoids having to pull this in as an explicit include directory for projects that depend on cppdap.