### PR TITLE
Fix socket receiving error

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -173,8 +173,17 @@ class dap::Socket::Shared : public dap::ReaderWriter {
     if (bytes == 0) {
       return true;
     }
-    return ::send(s, reinterpret_cast<const char*>(buffer),
-                  static_cast<int>(bytes), 0) > 0;
+    const char* p = static_cast<const char*>(buffer);
+    while (bytes != 0 ) {
+      const size_t c = 1024 < bytes ? 1024 : bytes;
+      const int n = ::send(s, p, c, 0);
+      if (n <= 0 || n > c) 
+          return false;
+      p += n;
+
+      bytes -= n;
+    }
+    return true;
   }
 
   addrinfo* const info;

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -158,7 +158,11 @@ class dap::Socket::Shared : public dap::ReaderWriter {
     if (s == InvalidSocket) {
       return 0;
     }
-    return recv(s, reinterpret_cast<char*>(buffer), static_cast<int>(bytes), 0);
+    const int len = recv(s, reinterpret_cast<char*>(buffer), static_cast<int>(bytes), 0);
+    if (len < 0) {
+      return 0;
+    }
+    return len;
   }
 
   bool write(const void* buffer, size_t bytes) {


### PR DESCRIPTION
1. When the socket connection is disconnected, the recv function may return a negative number
2. for ContentReader::buffer. The received data may be less than the length of buf, this time will cause some dirty data to be read
3.catch json exception when processmessage
4.error callback can handle more string. no just 2049 byte .