### PR TITLE
Add the ability to derive message types from one another.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ if(CPPDAP_BUILD_TESTS)
         ${CPPDAP_SRC_DIR}/network_test.cpp
         ${CPPDAP_SRC_DIR}/optional_test.cpp
         ${CPPDAP_SRC_DIR}/session_test.cpp
+        ${CPPDAP_SRC_DIR}/typeinfo_test.cpp
         ${CPPDAP_SRC_DIR}/variant_test.cpp
         ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
     )

--- a/src/json_serializer.h
+++ b/src/json_serializer.h
@@ -67,11 +67,6 @@ struct Deserializer : public dap::Deserializer {
     return dap::Deserializer::deserialize(v);
   }
 
-  inline bool deserialize(void* o,
-                          const std::initializer_list<Field>& f) const {
-    return dap::Deserializer::deserialize(o, f);
-  }
-
   template <typename T>
   inline bool field(const std::string& name, T* v) const {
     return dap::Deserializer::deserialize(name, v);
@@ -94,23 +89,14 @@ struct Serializer : public dap::Serializer {
   bool serialize(integer v) override;
   bool serialize(number v) override;
   bool serialize(const string& v) override;
-  bool serialize(const object& v) override;
+  bool serialize(const dap::object& v) override;
   bool serialize(const any& v) override;
   bool array(size_t count,
              const std::function<bool(dap::Serializer*)>&) override;
-  bool fields(const void* object,
-              const std::initializer_list<Field>& fields) override;
-  bool field(const std::string& name, const FieldSerializer&) override;
+  bool object(const std::function<bool(dap::FieldSerializer*)>&) override;
   void remove() override;
 
   // Unhide base overloads
-  template <
-      typename T,
-      typename = typename std::enable_if<!IsFieldSerializer<T>::value>::type>
-  inline bool field(const std::string& name, const T& v) {
-    return dap::Serializer::field(name, v);
-  }
-
   template <typename T,
             typename = std::enable_if<TypeOf<T>::has_custom_serialization>>
   inline bool serialize(const T& v) {

--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -20,8 +20,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <nlohmann/json.hpp>
-
 namespace dap {
 
 struct JSONInnerTestObject {

--- a/src/typeinfo_test.cpp
+++ b/src/typeinfo_test.cpp
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dap/typeof.h"
+#include "dap/types.h"
+#include "json_serializer.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace dap {
+
+struct BaseStruct {
+  dap::integer i;
+  dap::number n;
+};
+
+DAP_STRUCT_TYPEINFO(BaseStruct,
+                    "BaseStruct",
+                    DAP_FIELD(i, "i"),
+                    DAP_FIELD(n, "n"));
+
+struct DerivedStruct : public BaseStruct {
+  dap::string s;
+  dap::boolean b;
+};
+
+DAP_STRUCT_TYPEINFO_EXT(DerivedStruct,
+                        BaseStruct,
+                        "DerivedStruct",
+                        DAP_FIELD(s, "s"),
+                        DAP_FIELD(b, "b"));
+
+}  // namespace dap
+
+TEST(TypeInfo, Derived) {
+  dap::DerivedStruct in;
+  in.s = "hello world";
+  in.b = true;
+  in.i = 42;
+  in.n = 3.14;
+
+  dap::json::Serializer s;
+  ASSERT_TRUE(s.serialize(in));
+
+  dap::DerivedStruct out;
+  dap::json::Deserializer d(s.dump());
+  ASSERT_TRUE(d.deserialize(&out)) << "Failed to deserialize\n" << s.dump();
+
+  ASSERT_EQ(out.s, "hello world");
+  ASSERT_EQ(out.b, true);
+  ASSERT_EQ(out.i, 42);
+  ASSERT_EQ(out.n, 3.14);
+}


### PR DESCRIPTION
`DAP_IMPLEMENT_STRUCT_TYPEINFO_EXT` and `DAP_STRUCT_TYPEINFO_EXT` are two new flavors of `DAP_IMPLEMENT_STRUCT_TYPEINFO` and `DAP_STRUCT_TYPEINFO` that allow you to derive message types.

This involved a bit of reworking on the serializer interfaces.

Added test.

Issue: #32