### PR TITLE
Add license checker config and kokoro presubmit

### DIFF
--- a/clang-format-all.sh
+++ b/clang-format-all.sh
@@ -1,3 +1,17 @@
+# Copyright 2020 The Marl Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SRC_DIR=${ROOT_DIR}/src
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}

--- a/kokoro/license-check/presubmit-docker.sh
+++ b/kokoro/license-check/presubmit-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2020 The Marl Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,4 @@
 
 set -e # Fail on any error.
 
-ROOT_DIR=`pwd`
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
-
-docker run --rm -i \
-  --volume "${ROOT_DIR}:${ROOT_DIR}" \
-  --volume "${KOKORO_ARTIFACTS_DIR}:/mnt/artifacts" \
-  --workdir "${ROOT_DIR}" \
-  --env BUILD_SYSTEM=$BUILD_SYSTEM \
-  --env BUILD_TARGET_ARCH=$BUILD_TARGET_ARCH \
-  --env BUILD_SANITIZER=$BUILD_SANITIZER \
-  --entrypoint "${SCRIPT_DIR}/presubmit-docker.sh" \
-  "gcr.io/shaderc-build/radial-build:latest"
+license-checker

--- a/kokoro/license-check/presubmit.cfg
+++ b/kokoro/license-check/presubmit.cfg
@@ -1,0 +1,4 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "cppdap/kokoro/license-check/presubmit.sh"
+

--- a/kokoro/license-check/presubmit.sh
+++ b/kokoro/license-check/presubmit.sh
@@ -16,15 +16,12 @@
 
 set -e # Fail on any error.
 
-ROOT_DIR=`pwd`
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
 docker run --rm -i \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
   --volume "${KOKORO_ARTIFACTS_DIR}:/mnt/artifacts" \
   --workdir "${ROOT_DIR}" \
-  --env BUILD_SYSTEM=$BUILD_SYSTEM \
-  --env BUILD_TARGET_ARCH=$BUILD_TARGET_ARCH \
-  --env BUILD_SANITIZER=$BUILD_SANITIZER \
   --entrypoint "${SCRIPT_DIR}/presubmit-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"

--- a/kokoro/macos/presubmit.sh
+++ b/kokoro/macos/presubmit.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e # Fail on any error.
 set -x # Display commands being run.
 

--- a/kokoro/ubuntu/presubmit-docker.sh
+++ b/kokoro/ubuntu/presubmit-docker.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e # Fail on any error.
 
 . /bin/using.sh # Declare the bash `using` function for configuring toolchains.

--- a/kokoro/windows/presubmit.bat
+++ b/kokoro/windows/presubmit.bat
@@ -1,3 +1,17 @@
+REM Copyright 2020 Google LLC
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     https://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
 @echo on
 
 SETLOCAL ENABLEDELAYEDEXPANSION

--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,0 +1,24 @@
+{
+    "licenses": [
+        "Apache-2.0-Header"
+    ],
+    "paths": [
+        {
+            "exclude": [
+                ".clang-format",
+                ".gitignore",
+                ".gitmodules",
+                ".vscode/*.json",
+                "**.md",
+                "CONTRIBUTING",
+                "LICENSE",
+                "build/**",
+                "examples/vscode/package.json",
+                "fuzz/**",
+                "kokoro/**.cfg",
+                "third_party/googletest/**",
+                "third_party/json/**"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
`license-checker` is a tool that verifies each file has contains a permitted license header.

See https://github.com/ben-clayton/license-checker for more information.

Also add missing licenses to presubmit scripts.