### PR TITLE
Fix content reader for partial input

### DIFF
--- a/src/content_stream.h
+++ b/src/content_stream.h
@@ -47,6 +47,7 @@ class ContentReader {
 
   std::shared_ptr<Reader> reader;
   std::deque<uint8_t> buf;
+  uint32_t matched_idx = 0;
 };
 
 class ContentWriter {

--- a/src/content_stream_test.cpp
+++ b/src/content_stream_test.cpp
@@ -81,3 +81,19 @@ TEST(ContentStreamTest, ShortRead) {
   ASSERT_EQ(cs.read(), "Content payload number three");
   ASSERT_EQ(cs.read(), "");
 }
+
+TEST(ContentStreamTest, PartialReadAndParse) {
+  auto sb = std::make_shared<dap::StringBuffer>();
+  dap::ContentReader cs(sb);
+  sb->write("Content");
+  ASSERT_EQ(cs.read(), "");
+  sb->write("-Length: ");
+  ASSERT_EQ(cs.read(), "");
+  sb->write("26");
+  ASSERT_EQ(cs.read(), "");
+  sb->write("\r\n\r\n");
+  ASSERT_EQ(cs.read(), "");
+  sb->write("Content payload number one");
+  ASSERT_EQ(cs.read(), "Content payload number one");
+  ASSERT_EQ(cs.read(), "");
+}


### PR DESCRIPTION
When there is partial message in reader, popping out the
characters lead to parse errors on the subsequent attempt
to parse. To avoid this, the last matched characters'
index is stored during parsing and reset on error.