### PR TITLE
license-checker.cfg: Update rules

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,5 +1,6 @@
 {
     "licenses": [
+        "Apache-2.0",
         "Apache-2.0-Header"
     ],
     "paths": [
@@ -17,7 +18,8 @@
                 "fuzz/**",
                 "kokoro/**.cfg",
                 "third_party/googletest/**",
-                "third_party/json/**"
+                "third_party/json/**",
+                "third_party/rapidjson/**"
             ]
         }
     ]


### PR DESCRIPTION
The license classification rules in github.com/google/licensecheck have been updated.