### PR TITLE
json serializers: Support 64-bit integers.

### DIFF
--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -65,7 +65,7 @@ TEST(JSONSerializer, SerializeDeserialize) {
   encoded.b = true;
   encoded.i = 32;
   encoded.n = 123.456;
-  encoded.a = {2, 4, 6, 8};
+  encoded.a = {2, 4, 6, 8, 0x100000000, -2, -4, -6, -8, -0x100000000};
   encoded.o["one"] = dap::integer(1);
   encoded.o["two"] = dap::number(2);
   encoded.s = "hello world";

--- a/src/nlohmann_json_serializer.cpp
+++ b/src/nlohmann_json_serializer.cpp
@@ -49,7 +49,7 @@ bool NlohmannDeserializer::deserialize(dap::integer* v) const {
   if (!json->is_number_integer()) {
     return false;
   }
-  *v = json->get<int>();
+  *v = json->get<int64_t>();
   return true;
 }
 
@@ -88,7 +88,7 @@ bool NlohmannDeserializer::deserialize(dap::any* v) const {
   } else if (json->is_number_float()) {
     *v = dap::number(json->get<double>());
   } else if (json->is_number_integer()) {
-    *v = dap::integer(json->get<int>());
+    *v = dap::integer(json->get<int64_t>());
   } else if (json->is_string()) {
     *v = json->get<std::string>();
   } else if (json->is_null()) {
@@ -154,7 +154,7 @@ bool NlohmannSerializer::serialize(dap::boolean v) {
 }
 
 bool NlohmannSerializer::serialize(dap::integer v) {
-  *json = (int)v;
+  *json = (int64_t)v;
   return true;
 }
 
@@ -182,7 +182,7 @@ bool NlohmannSerializer::serialize(const dap::any& v) {
   if (v.is<dap::boolean>()) {
     *json = (bool)v.get<dap::boolean>();
   } else if (v.is<dap::integer>()) {
-    *json = (int)v.get<dap::integer>();
+    *json = (int64_t)v.get<dap::integer>();
   } else if (v.is<dap::number>()) {
     *json = (double)v.get<dap::number>();
   } else if (v.is<dap::string>()) {

--- a/src/rapid_json_serializer.cpp
+++ b/src/rapid_json_serializer.cpp
@@ -42,11 +42,20 @@ bool RapidDeserializer::deserialize(dap::boolean* v) const {
 }
 
 bool RapidDeserializer::deserialize(dap::integer* v) const {
-  if (!json()->IsInt()) {
-    return false;
+  if (json()->IsInt()) {
+    *v = json()->GetInt();
+    return true;
+  } else if (json()->IsUint()) {
+    *v = static_cast<int64_t>(json()->GetUint());
+    return true;
+  } else if (json()->IsInt64()) {
+    *v = json()->GetInt64();
+    return true;
+  } else if (json()->IsUint64()) {
+    *v = static_cast<int64_t>(json()->GetUint64());
+    return true;
   }
-  *v = json()->GetInt();
-  return true;
+  return false;
 }
 
 bool RapidDeserializer::deserialize(dap::number* v) const {
@@ -188,7 +197,7 @@ bool RapidSerializer::serialize(const dap::any& v) {
   if (v.is<dap::boolean>()) {
     json()->SetBool((bool)v.get<dap::boolean>());
   } else if (v.is<dap::integer>()) {
-    json()->SetInt((int)v.get<dap::integer>());
+    json()->SetInt64(v.get<dap::integer>());
   } else if (v.is<dap::number>()) {
     json()->SetDouble((double)v.get<dap::number>());
   } else if (v.is<dap::string>()) {


### PR DESCRIPTION
Fixes: #66