### PR TITLE
Fix valid function invoke failed in future class

### DIFF
--- a/include/dap/future.h
+++ b/include/dap/future.h
@@ -93,7 +93,7 @@ future<T>::future(const std::shared_ptr<State>& s) : state(s) {}
 
 template <typename T>
 bool future<T>::valid() const {
-  return state;
+  return static_cast<bool>(state);
 }
 
 template <typename T>


### PR DESCRIPTION
In C++11, shared_ptr has an explicit operator bool which
means that a shared_ptr can't be implicitly converted to a bool.
adding an explicit cast is a valid fix to the code.