### PR TITLE
fix bug in processEvent function

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -399,9 +399,10 @@ class Impl : public dap::Session {
           return typeinfo->deserialize(d, data);
         })) {
       handlers.error("Failed to deserialize event '%s' body", event.c_str());
-      typeinfo->destruct(data);
-      delete[] data;
-      return {};
+      // "body" field in TerminatedEvent is an optional field.
+      //typeinfo->destruct(data);
+      //delete[] data;
+      //return {};
     }
 
     return [=] {


### PR DESCRIPTION
"body" field in "Terminated Event" is an optional field, but if no "body" will return {} in processEvent function.

![image](https://user-images.githubusercontent.com/112470190/207536034-fdfac58f-7128-4a5a-a5ba-76ec2f72c7c5.png)
![image](https://user-images.githubusercontent.com/112470190/207536177-5adb3a15-afe7-4364-af6a-cfd23646f1d6.png)
