### PR TITLE
fix bug in processEvent function

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -395,13 +395,20 @@ class Impl : public dap::Session {
     auto data = new uint8_t[typeinfo->size()];
     typeinfo->construct(data);
 
-    if (!d->field("body", [&](dap::Deserializer* d) {
-          return typeinfo->deserialize(d, data);
-        })) {
-      handlers.error("Failed to deserialize event '%s' body", event.c_str());
-      typeinfo->destruct(data);
-      delete[] data;
-      return {};
+    // "body" is an optional field for some events, such as "Terminated Event".
+    bool body_ok = true;
+    d->field("body", [&](dap::Deserializer* d) {
+        if (!typeinfo->deserialize(d, data)) {
+            body_ok = false;
+        }
+        return true;
+    });
+
+    if (!body_ok) {
+        handlers.error("Failed to deserialize event '%s' body", event.c_str());
+        typeinfo->destruct(data);
+        delete[] data;
+        return {};
     }
 
     return [=] {


### PR DESCRIPTION
"body" field in "Terminated Event" is an optional field, but if no "body" will return {} in processEvent function.

DAP protocol:
![image](https://user-images.githubusercontent.com/112470190/210711591-8b89e180-fc83-40aa-93d9-7ba99036d3fc.png)

code in session.cpp:
![image](https://user-images.githubusercontent.com/112470190/210711647-1b16f321-4d23-4fa1-be96-4b4e0e90427c.png)
