### PR TITLE
Fix `any`, embedded `object`, `array`, and struct serialization

### DIFF
--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -23,6 +23,8 @@ namespace dap {
 
 template <typename T>
 struct TypeOf;
+class Deserializer;
+class Serializer;
 
 // any provides a type-safe container for values of any of dap type (boolean,
 // integer, number, array, variant, any, null, dap-structs).
@@ -58,6 +60,9 @@ class any {
   inline bool is() const;
 
  private:
+  friend class Deserializer;
+  friend class Serializer;
+
   static inline void* alignUp(void* val, size_t alignment);
   inline void alloc(size_t size, size_t align);
   inline void free();

--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -49,11 +49,16 @@ class any {
   inline any& operator=(any&& rhs) noexcept;
   template <typename T>
   inline any& operator=(const T& val);
+  template <>
+  inline any& operator=(const std::nullptr_t& val);
 
   // get() returns the contained value of the type T.
   // If the any does not contain a value of type T, then get() will assert.
   template <typename T>
   inline T& get() const;
+
+  template <>
+  inline std::nullptr_t& get() const;
 
   // is() returns true iff the contained value is of type T.
   template <typename T>
@@ -147,8 +152,16 @@ any& any::operator=(const T& val) {
   return *this;
 }
 
+template <>
+any& any::operator=(const nullptr_t&) {
+  reset();
+  return *this;
+}
+
 template <typename T>
 T& any::get() const {
+  static_assert(!std::is_same<T, std::nullptr_t>(),
+                "Cannot get nullptr from 'any'.");
   assert(is<T>());
   return *reinterpret_cast<T*>(value);
 }

--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -57,9 +57,6 @@ class any {
   template <typename T>
   inline T& get() const;
 
-  template <>
-  inline std::nullptr_t& get() const;
-
   // is() returns true iff the contained value is of type T.
   template <typename T>
   inline bool is() const;

--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -49,7 +49,7 @@ class any {
   inline any& operator=(any&& rhs) noexcept;
   template <typename T>
   inline any& operator=(const T& val);
-  template <>
+  template <typename = std::nullptr_t>
   inline any& operator=(const std::nullptr_t& val);
 
   // get() returns the contained value of the type T.
@@ -149,8 +149,8 @@ any& any::operator=(const T& val) {
   return *this;
 }
 
-template <>
-any& any::operator=(const nullptr_t&) {
+template <typename>
+any& any::operator=(const std::nullptr_t&) {
   reset();
   return *this;
 }

--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -49,7 +49,6 @@ class any {
   inline any& operator=(any&& rhs) noexcept;
   template <typename T>
   inline any& operator=(const T& val);
-  template <typename = std::nullptr_t>
   inline any& operator=(const std::nullptr_t& val);
 
   // get() returns the contained value of the type T.
@@ -149,7 +148,6 @@ any& any::operator=(const T& val) {
   return *this;
 }
 
-template <typename>
 any& any::operator=(const std::nullptr_t&) {
   reset();
   return *this;

--- a/include/dap/serialization.h
+++ b/include/dap/serialization.h
@@ -177,7 +177,17 @@ class Serializer {
 
   // deserialize() encodes the given string.
   inline bool serialize(const char* v);
+ protected:
+  static inline const TypeInfo* get_any_type(const any&);
+  static inline const void* get_any_val(const any&);
 };
+
+inline const TypeInfo* Serializer::get_any_type(const any& a){
+  return a.type;
+}
+const void* Serializer::get_any_val(const any& a) {
+  return a.value;
+}
 
 template <typename T, typename>
 bool Serializer::serialize(const T& object) {

--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -204,7 +204,7 @@ TEST_F(JSONSerializer, SerializeDeserializeEmbeddedIntArray) {
   ASSERT_TRUE(decoded["embed_arr"].is<dap::array<dap::any>>());
   decoded_embed_arr = decoded["embed_arr"].get<dap::array<dap::any>>();
   ASSERT_EQ(encoded_embed_arr.size(), decoded_embed_arr.size());
-  for (int i = 0; i < decoded_embed_arr.size(); i++) {
+  for (std::size_t i = 0; i < decoded_embed_arr.size(); i++) {
     ASSERT_TRUE(decoded_embed_arr[i].is<dap::integer>());
     ASSERT_EQ(encoded_embed_arr[i], decoded_embed_arr[i].get<dap::integer>());
   }
@@ -225,7 +225,7 @@ TEST_F(JSONSerializer, SerializeDeserializeEmbeddedObjectArray) {
   ASSERT_TRUE(decoded["embed_arr"].is<dap::array<dap::any>>());
   decoded_embed_arr = decoded["embed_arr"].get<dap::array<dap::any>>();
   ASSERT_EQ(encoded_embed_arr.size(), decoded_embed_arr.size());
-  for (int i = 0; i < decoded_embed_arr.size(); i++) {
+  for (std::size_t i = 0; i < decoded_embed_arr.size(); i++) {
     ASSERT_TRUE(decoded_embed_arr[i].is<dap::object>());
     _ASSERT_PASS(TEST_SIMPLE_OBJECT(decoded_embed_arr[i].get<dap::object>()));
   }

--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -223,3 +223,16 @@ TEST_F(JSONSerializer, SerializeDeserializeEmbeddedEmptyObject) {
   dap::object decoded_empty_obj = decoded["empty_obj"].get<dap::object>();
   ASSERT_EQ(encoded_empty_obj.size(), decoded_empty_obj.size());
 }
+
+TEST_F(JSONSerializer, SerializeDeserializeObjectWithNulledField) {
+  auto thing = dap::any(dap::null());
+  dap::object encoded;
+  encoded["nulled_field"] = dap::null();
+  dap::json::Serializer s;
+  ASSERT_TRUE(s.serialize(encoded));
+  dap::object decoded;
+  auto dump = s.dump();
+  dap::json::Deserializer d(dump);
+  ASSERT_TRUE(d.deserialize(&decoded));
+  ASSERT_TRUE(encoded["nulled_field"].is<dap::null>());
+}

--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -58,6 +58,15 @@ struct JSONObjectNoFields {};
 
 DAP_STRUCT_TYPEINFO(JSONObjectNoFields, "json-object-no-fields");
 
+struct SimpleJSONTestObject {
+  boolean b;
+  integer i;
+};
+DAP_STRUCT_TYPEINFO(SimpleJSONTestObject,
+                    "simple-json-test-object",
+                    DAP_FIELD(b, "b"),
+                    DAP_FIELD(i, "i"));
+
 }  // namespace dap
 
 class JSONSerializer : public testing::Test {
@@ -154,12 +163,31 @@ TEST_F(JSONSerializer, SerializeDeserializeEmbeddedObject) {
   // object nested inside object
   dap::object encoded_embed_obj = GetSimpleObject();
   dap::object decoded_embed_obj;
-
   encoded["embed_obj"] = encoded_embed_obj;
   _ASSERT_PASS(TEST_SERIALIZING_DESERIALIZING(encoded, decoded));
   ASSERT_TRUE(decoded["embed_obj"].is<dap::object>());
   decoded_embed_obj = decoded["embed_obj"].get<dap::object>();
   _ASSERT_PASS(TEST_SIMPLE_OBJECT(decoded_embed_obj));
+}
+
+TEST_F(JSONSerializer, SerializeDeserializeEmbeddedStruct) {
+  dap::object encoded;
+  dap::object decoded;
+  // object nested inside object
+  dap::SimpleJSONTestObject encoded_embed_struct;
+  encoded_embed_struct.b = true;
+  encoded_embed_struct.i = 50;
+  encoded["embed_struct"] = encoded_embed_struct;
+
+  dap::object decoded_embed_obj;
+  _ASSERT_PASS(TEST_SERIALIZING_DESERIALIZING(encoded, decoded));
+  ASSERT_TRUE(decoded["embed_struct"].is<dap::object>());
+  decoded_embed_obj = decoded["embed_struct"].get<dap::object>();
+  ASSERT_TRUE(decoded_embed_obj.at("b").is<dap::boolean>());
+  ASSERT_TRUE(decoded_embed_obj.at("i").is<dap::integer>());
+
+  ASSERT_EQ(encoded_embed_struct.b, decoded_embed_obj["b"].get<dap::boolean>());
+  ASSERT_EQ(encoded_embed_struct.i, decoded_embed_obj["i"].get<dap::integer>());
 }
 
 TEST_F(JSONSerializer, SerializeDeserializeEmbeddedIntArray) {

--- a/src/json_serializer_test.cpp
+++ b/src/json_serializer_test.cpp
@@ -202,3 +202,24 @@ TEST_F(JSONSerializer, SerializeDeserializeEmbeddedObjectArray) {
     _ASSERT_PASS(TEST_SIMPLE_OBJECT(decoded_embed_arr[i].get<dap::object>()));
   }
 }
+
+TEST_F(JSONSerializer, DeserializeSerializeEmptyObject) {
+  auto empty_obj = "{}";
+  dap::object decoded;
+  dap::json::Deserializer d(empty_obj);
+  ASSERT_TRUE(d.deserialize(&decoded));
+  dap::json::Serializer s;
+  ASSERT_TRUE(s.serialize(decoded));
+  ASSERT_EQ(s.dump(), empty_obj);
+}
+
+TEST_F(JSONSerializer, SerializeDeserializeEmbeddedEmptyObject) {
+  dap::object encoded_empty_obj;
+  dap::object encoded = {{"empty_obj", encoded_empty_obj}};
+  dap::object decoded;
+
+  _ASSERT_PASS(TEST_SERIALIZING_DESERIALIZING(encoded, decoded));
+  ASSERT_TRUE(decoded["empty_obj"].is<dap::object>());
+  dap::object decoded_empty_obj = decoded["empty_obj"].get<dap::object>();
+  ASSERT_EQ(encoded_empty_obj.size(), decoded_empty_obj.size());
+}

--- a/src/nlohmann_json_serializer.cpp
+++ b/src/nlohmann_json_serializer.cpp
@@ -91,6 +91,18 @@ bool NlohmannDeserializer::deserialize(dap::any* v) const {
     *v = dap::integer(json->get<int64_t>());
   } else if (json->is_string()) {
     *v = json->get<std::string>();
+  } else if (json->is_object()) {
+    dap::object obj;
+    if (!deserialize(&obj)) {
+      return false;
+    }
+    *v = obj;
+  } else if (json->is_array()) {
+    dap::array<any> arr;
+    if (!deserialize(&arr)) {
+      return false;
+    }
+    *v = arr;
   } else if (json->is_null()) {
     *v = null();
   } else {
@@ -187,11 +199,19 @@ bool NlohmannSerializer::serialize(const dap::any& v) {
     *json = (double)v.get<dap::number>();
   } else if (v.is<dap::string>()) {
     *json = v.get<dap::string>();
+  } else if (v.is<dap::object>()) {
+    // reachable if dap::object nested is inside other dap::object
+    return serialize(v.get<dap::object>());
   } else if (v.is<dap::null>()) {
   } else {
+    // reachable if array or custom serialized type is nested inside other
+    auto type = get_any_type(v);
+    auto value = get_any_val(v);
+    if (type && value) {
+      return type->serialize(this, value);
+    }
     return false;
   }
-
   return true;
 }
 

--- a/src/nlohmann_json_serializer.cpp
+++ b/src/nlohmann_json_serializer.cpp
@@ -181,6 +181,9 @@ bool NlohmannSerializer::serialize(const dap::string& v) {
 }
 
 bool NlohmannSerializer::serialize(const dap::object& v) {
+  if (!json->is_object()) {
+    *json = nlohmann::json::object();
+  }
   for (auto& it : v) {
     NlohmannSerializer s(&(*json)[it.first]);
     if (!s.serialize(it.second)) {


### PR DESCRIPTION
This PR fixes a few bugs I uncovered while fixing the previous bug:

-  nlohmann_json was serializing empty objects as `null` rather than `{}`.

- `any` did not handle assignment to a nullptr_t value, and threw a SEH exception. This was very difficult to track down as a result, so I had `any` handle it by calling `any.reset()` on assignment to a nullptr value. 
  - We would encounter this while serializing/deserializing `RunInTerminalRequestArguments` which allows `null` in `env`, [see the spec here](https://github.com/microsoft/debug-adapter-protocol/blob/main/debugAdapterProtocol.json#L779)
  
- structs, objects, and arrays embedded inside of another `object` were failing to be serialized and deserialized. I changed it such that when we de/serialize `any`, we handle these too.
  - While most of the spec only has arbitrary-field objects with specific types (like `string` or `string | null`), it does have examples of arbitrary data which is expected to be de-serialized by the client and looped back to the server. See the spec for [TerminatedEvent](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Terminated)
  - We might want to handle arbitrary-field objects with specific types differently; perhaps a new type of `dap::dict<T>`?
  - We don’t handle deserializing an `object`-embedded serialized struct back into a struct, we deserialize it into an `object`; it’s expected that if it’s arbitrary data, the server implementation will handle them