### PR TITLE
cmake: Avoid exposing implementation dependencies publicly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 
 function(cppdap_set_json_links target)
     if (CPPDAP_USE_EXTERNAL_NLOHMANN_JSON_PACKAGE)
-        target_link_libraries(${target} PRIVATE nlohmann_json nlohmann_json::nlohmann_json)
+        target_link_libraries(${target} PRIVATE "$<BUILD_INTERFACE:nlohmann_json::nlohmann_json>")
     elseif(CPPDAP_USE_EXTERNAL_RAPIDJSON_PACKAGE)
         target_link_libraries(${target} PRIVATE rapidjson)
     else()
@@ -164,7 +164,7 @@ function(cppdap_set_target_options target)
 
     # Add define for JSON library in use
     target_compile_definitions(${target}
-        PUBLIC "CPPDAP_JSON_${CPPDAP_JSON_LIBRARY_UPPER}=1"
+        PRIVATE "CPPDAP_JSON_${CPPDAP_JSON_LIBRARY_UPPER}=1"
     )
 
     # Treat all warnings as errors


### PR DESCRIPTION
The `CPPDAP_JSON_{NLOHMANN,RAPID}` compile definition is used only in cppdap's implementation sources, and does not need to be defined by dependents including our headers.

Also avoid exposing `nlohmann_json::nlohmann_json` as a public link dependency of our installed package.  It is used only when compiling cppdap.