### PR TITLE
Fix compiler warning and error encountered on some platforms

### DIFF
--- a/include/dap/typeof.h
+++ b/include/dap/typeof.h
@@ -161,11 +161,11 @@ M member_type(M T::*);
 // DAP_IMPLEMENT_STRUCT_TYPEINFO_EXT().
 // You probably do not want to use this directly.
 #define DAP_IMPLEMENT_STRUCT_FIELD_SERIALIZATION(STRUCT, NAME, ...)           \
-  bool TypeOf<STRUCT>::deserializeFields(const Deserializer* d, void* obj) {  \
+  bool TypeOf<STRUCT>::deserializeFields(const Deserializer* fd, void* obj) { \
     using StructTy = STRUCT;                                                  \
     (void)sizeof(StructTy); /* avoid unused 'using' warning */                \
     for (auto field : std::initializer_list<Field>{__VA_ARGS__}) {            \
-      if (!d->field(field.name, [&](Deserializer* d) {                        \
+      if (!fd->field(field.name, [&](Deserializer* d) {                       \
             auto ptr = reinterpret_cast<uint8_t*>(obj) + field.offset;        \
             return field.type->deserialize(d, ptr);                           \
           })) {                                                               \
@@ -174,11 +174,11 @@ M member_type(M T::*);
     }                                                                         \
     return true;                                                              \
   }                                                                           \
-  bool TypeOf<STRUCT>::serializeFields(FieldSerializer* s, const void* obj) { \
+  bool TypeOf<STRUCT>::serializeFields(FieldSerializer* fs, const void* obj) {\
     using StructTy = STRUCT;                                                  \
     (void)sizeof(StructTy); /* avoid unused 'using' warning */                \
     for (auto field : std::initializer_list<Field>{__VA_ARGS__}) {            \
-      if (!s->field(field.name, [&](Serializer* s) {                          \
+      if (!fs->field(field.name, [&](Serializer* s) {                         \
             auto ptr = reinterpret_cast<const uint8_t*>(obj) + field.offset;  \
             return field.type->serialize(s, ptr);                             \
           })) {                                                               \

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -21,6 +21,7 @@
 #include <cstring>  // strlen
 #include <deque>
 #include <mutex>
+#include <string>
 
 namespace {
 


### PR DESCRIPTION
Avoid `-Wshadow-uncaptured-local` warnings in `DAP_IMPLEMENT_STRUCT_TYPEINFO`.  Previously, applications using `DAP_IMPLEMENT_STRUCT_TYPEINFO` may see:

    <app-file>:<app-line>:1: warning: declaration shadows a local variable [-Wshadow-uncaptured-local]
    DAP_IMPLEMENT_STRUCT_TYPEINFO(<app-args>),
    ^
    /.../include/dap/typeof.h:199:3: note: expanded from macro 'DAP_IMPLEMENT_STRUCT_TYPEINFO'
    DAP_IMPLEMENT_STRUCT_FIELD_SERIALIZATION(STRUCT, NAME, __VA_ARGS__)       \
    ^
    /.../include/dap/typeof.h:168:51: note: expanded from macro 'DAP_IMPLEMENT_STRUCT_FIELD_SERIALIZATION'
        if (!d->field(field.name, [&](Deserializer* d) {                        \
                                                    ^
    <app-file>:<app-line>:1: note: previous declaration is here
    /.../include/dap/typeof.h:199:3: note: expanded from macro 'DAP_IMPLEMENT_STRUCT_TYPEINFO'
    DAP_IMPLEMENT_STRUCT_FIELD_SERIALIZATION(STRUCT, NAME, __VA_ARGS__)       \
    ^
    /.../include/dap/typeof.h:164:62: note: expanded from macro 'DAP_IMPLEMENT_STRUCT_FIELD_SERIALIZATION'
    bool TypeOf<STRUCT>::deserializeFields(const Deserializer* d, void* obj) {  \
                                                               ^

Also, add a missing include for `std::string` in `src/io.cpp`.