### PR TITLE
any: Tell clang-analyzer a pointer is not nullptr

### DIFF
--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -143,6 +143,9 @@ any& any::operator=(const T& val) {
     alloc(type->size(), type->alignment());
     type->copyConstruct(value, &val);
   } else {
+#ifdef __clang_analyzer__
+    assert(value != nullptr);
+#endif
     *reinterpret_cast<T*>(value) = val;
   }
   return *this;


### PR DESCRIPTION
Previously, clang-analyzer warned:

    /.../any.h:146:5: warning: Called C++ object pointer is null [core.CallAndMessage]

We already have similar assertions elsewhere.