### PR TITLE
any: Add missing include <stdint.h>

### DIFF
--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -18,6 +18,7 @@
 #include "typeinfo.h"
 
 #include <assert.h>
+#include <stdint.h>
 
 namespace dap {
 


### PR DESCRIPTION
We use `uint8_t` and `uintptr_t` from this header.