### PR TITLE
optional: Fix compilation on XLClang 16.1.0

### DIFF
--- a/include/dap/optional.h
+++ b/include/dap/optional.h
@@ -75,7 +75,7 @@ class optional {
   inline T& operator*();
 
  private:
-  T val = {};
+  T val{};
   bool set = false;
 };
 


### PR DESCRIPTION
The compiler rejects initialization with `= {}`:

    error: chosen constructor is explicit in copy-initialization

Use just `{}` instead.