### PR TITLE
build(cmake): use min CMake version prior to project call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_policy(SET CMP0048 NEW)
-project(cppdap VERSION 1.59.0 LANGUAGES CXX C)
-
 cmake_minimum_required(VERSION 3.13)
+
+project(cppdap VERSION 1.59.0 LANGUAGES CXX C)
 
 set (CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
The [CMake documentation](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) mandates that `cmake_minimum_required` should be called early in the `CMakeLists.txt` prior to any `project()` command.