### PR TITLE
Fix infinite loop when parsing invalid DAP message.

### DIFF
--- a/examples/simple_net_client_server.cpp
+++ b/examples/simple_net_client_server.cpp
@@ -30,6 +30,11 @@ int main(int, char*[]) {
   auto onClientConnected =
       [&](const std::shared_ptr<dap::ReaderWriter>& socket) {
         auto session = dap::Session::create();
+
+        // Set the session to close on invalid data. This ensures that data received over the network
+        // receives a baseline level of validation before being processed.
+        session->setOnInvalidData(dap::kClose);
+
         session->bind(socket);
 
         // The Initialize request is the first message sent from the client and

--- a/include/dap/session.h
+++ b/include/dap/session.h
@@ -103,6 +103,14 @@ ResponseOrError<T>& ResponseOrError<T>::operator=(ResponseOrError&& other) {
 // Session
 ////////////////////////////////////////////////////////////////////////////////
 
+// An enum flag that controls how the Session handles invalid data.
+enum OnInvalidData {
+  // Ignore invalid data.
+  kIgnore,
+  // Close the underlying reader when invalid data is received.
+  kClose,
+};
+
 // Session implements a DAP client or server endpoint.
 // The general usage is as follows:
 // (1) Create a session with Session::create().
@@ -143,6 +151,9 @@ class Session {
 
   // create() constructs and returns a new Session.
   static std::unique_ptr<Session> create();
+
+  // Sets how the Session handles invalid data.
+  virtual void setOnInvalidData(OnInvalidData) = 0;
 
   // onError() registers a error handler that will be called whenever a protocol
   // error is encountered.

--- a/src/content_stream.h
+++ b/src/content_stream.h
@@ -47,7 +47,6 @@ class ContentReader {
 
   std::shared_ptr<Reader> reader;
   std::deque<uint8_t> buf;
-  uint32_t matched_idx = 0;
 };
 
 class ContentWriter {

--- a/src/content_stream.h
+++ b/src/content_stream.h
@@ -21,6 +21,8 @@
 
 #include <stdint.h>
 
+#include "dap/session.h"
+
 namespace dap {
 
 // Forward declarations
@@ -30,7 +32,8 @@ class Writer;
 class ContentReader {
  public:
   ContentReader() = default;
-  ContentReader(const std::shared_ptr<Reader>&);
+  ContentReader(const std::shared_ptr<Reader>&,
+                const OnInvalidData on_invalid_data = kIgnore);
   ContentReader& operator=(ContentReader&&) noexcept;
 
   bool isOpen();
@@ -44,9 +47,11 @@ class ContentReader {
   bool match(const char* str);
   char matchAny(const char* chars);
   bool buffer(size_t bytes);
+  std::string badHeader();
 
   std::shared_ptr<Reader> reader;
   std::deque<uint8_t> buf;
+  OnInvalidData on_invalid_data;
 };
 
 class ContentWriter {

--- a/src/content_stream_test.cpp
+++ b/src/content_stream_test.cpp
@@ -81,3 +81,16 @@ TEST(ContentStreamTest, ShortRead) {
   ASSERT_EQ(cs.read(), "Content payload number three");
   ASSERT_EQ(cs.read(), "");
 }
+
+TEST(ContentStreamTest, PartialReadAndParse) {
+  auto sb = std::make_shared<dap::StringBuffer>();
+  sb->write("Content");
+  sb->write("-Length: ");
+  sb->write("26");
+  sb->write("\r\n\r\n");
+  sb->write("Content payload number one");
+
+  dap::ContentReader cs(sb);
+  ASSERT_EQ(cs.read(), "Content payload number one");
+  ASSERT_EQ(cs.read(), "");
+}

--- a/src/content_stream_test.cpp
+++ b/src/content_stream_test.cpp
@@ -81,19 +81,3 @@ TEST(ContentStreamTest, ShortRead) {
   ASSERT_EQ(cs.read(), "Content payload number three");
   ASSERT_EQ(cs.read(), "");
 }
-
-TEST(ContentStreamTest, PartialReadAndParse) {
-  auto sb = std::make_shared<dap::StringBuffer>();
-  dap::ContentReader cs(sb);
-  sb->write("Content");
-  ASSERT_EQ(cs.read(), "");
-  sb->write("-Length: ");
-  ASSERT_EQ(cs.read(), "");
-  sb->write("26");
-  ASSERT_EQ(cs.read(), "");
-  sb->write("\r\n\r\n");
-  ASSERT_EQ(cs.read(), "");
-  sb->write("Content payload number one");
-  ASSERT_EQ(cs.read(), "Content payload number one");
-  ASSERT_EQ(cs.read(), "");
-}

--- a/src/content_stream_test.cpp
+++ b/src/content_stream_test.cpp
@@ -94,3 +94,33 @@ TEST(ContentStreamTest, PartialReadAndParse) {
   ASSERT_EQ(cs.read(), "Content payload number one");
   ASSERT_EQ(cs.read(), "");
 }
+
+TEST(ContentStreamTest, HttpRequest) {
+  const char* const part1 =
+      "POST / HTTP/1.1\r\n"
+      "Host: localhost:8001\r\n"
+      "Connection: keep-alive\r\n"
+      "Content-Length: 99\r\n";
+  const char* const part2 =
+      "Pragma: no-cache\r\n"
+      "Cache-Control: no-cache\r\n"
+      "Content-Type: text/plain;charset=UTF-8\r\n"
+      "Accept: */*\r\n"
+      "Origin: null\r\n"
+      "Sec-Fetch-Site: cross-site\r\n"
+      "Sec-Fetch-Mode: cors\r\n"
+      "Sec-Fetch-Dest: empty\r\n"
+      "Accept-Encoding: gzip, deflate, br\r\n"
+      "Accept-Language: en-US,en;q=0.9\r\n"
+      "\r\n"
+      "{\"type\":\"request\",\"command\":\"launch\",\"arguments\":{\"cmd\":\"/"
+      "bin/sh -c 'echo remote code execution'\"}}";
+
+  auto sb = dap::StringBuffer::create();
+  sb->write(part1);
+  sb->write(part2);
+
+  dap::ContentReader cr(std::move(sb), dap::kClose);
+  ASSERT_EQ(cr.read(), "");
+  ASSERT_FALSE(cr.isOpen());
+}

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -35,6 +35,10 @@ namespace {
 
 class Impl : public dap::Session {
  public:
+  void setOnInvalidData(dap::OnInvalidData onInvalidData_) override {
+    this->onInvalidData = onInvalidData_;
+  }
+
   void onError(const ErrorHandler& handler) override { handlers.put(handler); }
 
   void registerHandler(const dap::TypeInfo* typeinfo,
@@ -69,7 +73,7 @@ class Impl : public dap::Session {
       return;
     }
 
-    reader = dap::ContentReader(r);
+    reader = dap::ContentReader(r, this->onInvalidData);
     writer = dap::ContentWriter(w);
   }
 
@@ -490,6 +494,7 @@ class Impl : public dap::Session {
   dap::Chan<Payload> inbox;
   std::atomic<uint32_t> nextSeq = {1};
   std::mutex sendMutex;
+  dap::OnInvalidData onInvalidData = dap::kIgnore;
 };
 
 }  // anonymous namespace


### PR DESCRIPTION
Opening this PR per https://issuetracker.google.com/issues/282990958.

The reproduction recipe and more details are available in that issue. I can repost them here if needed.

This definitely might need some tweaks. Happy to make any changes to this approach.

---

This commit reworks `ContentReader::read` to better validate the incoming DAP message, closing the underlying `dap::Reader` in the event of an invalid message.

This fixes an infinite loop when parsing an invalid DAP message. In particular, the infinite loop occurs when a cross-site HTTP request from a browser running on the same host as a cppdap server is sent to the server. As cross-site requests to the localhost can be triggered by untrusted JavaScript, more validation of the DAP messages is required to protect cppdap-based servers from malicious requests.

This commit also includes:
- Changes to `ContentReader::read` to block until the complete message has been read from the underlying `dap::Reader` instead of returning an incomplete result when the underlying `dap::Reader` does not have data.
- A few new unit tests to test invalid DAP messages.
- Some changes to the existing unit tests for `ContentReader`, in particular those that were testing partial reads and discarding invalid messages without expecting the reader to be closed after receiving an invalid message.