### PR TITLE
Do not call freeaddrinfo(3) on nullptr

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -108,7 +108,6 @@ class dap::Socket::Shared : public dap::ReaderWriter {
       return out;
     }
 
-    freeaddrinfo(info);
     term();
     return nullptr;
   }
@@ -117,7 +116,9 @@ class dap::Socket::Shared : public dap::ReaderWriter {
   Shared(addrinfo* info, SOCKET socket) : info(info), s(socket) {}
 
   ~Shared() {
-    freeaddrinfo(info);
+    if (info) {
+        freeaddrinfo(info);
+    }
     close();
     term();
   }


### PR DESCRIPTION
freeaddrinfo(3) only defined to free one or more addrinfo structures returned by getaddrinfo(3).  Thus, it's undefined behaviour for calling freeaddrinfo(3) on nullptr, some libc only call free(3) on the the passed addrinfo, but other libc assumes the addrinfo is always valid.

Let's be explicit instead of relying on undefined behaviours.

Let's drop one call to freeaddrinfo(3) because the addrinfo there is always nullptr and guard the second.