### PR TITLE
Add missing `override` to `~Impl()`

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -138,7 +138,7 @@ class Impl : public dap::Session {
     return send(s.dump());
   }
 
-  ~Impl() {
+  ~Impl() override {
     inbox.close();
     reader.close();
     writer.close();


### PR DESCRIPTION
The other virtual methods are marked with `override`, so there's no good reason for the destructor to not have this too.