### PR TITLE
CMake: add CPPDAP_USE_EXTERNAL_GTEST_PACKAGE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option_if_not_defined(CPPDAP_INSTALL_VSCODE_EXAMPLES "Build and install dap exam
 option_if_not_defined(CPPDAP_USE_EXTERNAL_NLOHMANN_JSON_PACKAGE "Use nlohmann_json with find_package() instead of building internal submodule" OFF)
 option_if_not_defined(CPPDAP_USE_EXTERNAL_RAPIDJSON_PACKAGE "Use RapidJSON with find_package()" OFF)
 option_if_not_defined(CPPDAP_USE_EXTERNAL_JSONCPP_PACKAGE "Use JsonCpp with find_package()" OFF)
+option_if_not_defined(CPPDAP_USE_EXTERNAL_GTEST_PACKAGE "Use googletest with find_package()" OFF)
 
 ###########################################################
 # Directories
@@ -59,7 +60,7 @@ set_if_not_defined(CPPDAP_GOOGLETEST_DIR  ${CPPDAP_THIRD_PARTY_DIR}/googletest)
 ###########################################################
 # Submodules
 ###########################################################
-if(CPPDAP_BUILD_TESTS)
+if(CPPDAP_BUILD_TESTS AND NOT CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
     if(NOT EXISTS ${CPPDAP_GOOGLETEST_DIR}/.git)
         message(WARNING "third_party/googletest submodule missing.")
         message(WARNING "Run: `git submodule update --init` to build tests.")
@@ -161,7 +162,7 @@ function(cppdap_set_json_links target)
         target_link_libraries(${target} PRIVATE JsonCpp::JsonCpp)
     else()
         target_include_directories(${target} PRIVATE "${CPPDAP_JSON_DIR}/include/")
-    endif()    
+    endif()
 endfunction(cppdap_set_json_links)
 
 function(cppdap_set_target_options target)
@@ -247,7 +248,7 @@ write_basic_package_version_file(
 )
 configure_package_config_file(
 	${CPPDAP_CMAKE_CONFIG_TEMPLATE}
-	"${CPPDAP_CMAKE_PROJECT_CONFIG_FILE}" 
+	"${CPPDAP_CMAKE_PROJECT_CONFIG_FILE}"
 	INSTALL_DESTINATION ${CPPDAP_CONFIG_INSTALL_DIR}
 )
 
@@ -276,6 +277,8 @@ DESTINATION ${CPPDAP_CONFIG_INSTALL_DIR})
 
 # tests
 if(CPPDAP_BUILD_TESTS)
+    enable_testing()
+
     set(DAP_TEST_LIST
         ${CPPDAP_SRC_DIR}/any_test.cpp
         ${CPPDAP_SRC_DIR}/chan_test.cpp
@@ -290,16 +293,24 @@ if(CPPDAP_BUILD_TESTS)
         ${CPPDAP_SRC_DIR}/traits_test.cpp
         ${CPPDAP_SRC_DIR}/typeinfo_test.cpp
         ${CPPDAP_SRC_DIR}/variant_test.cpp
-        ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
     )
 
-    set(DAP_TEST_INCLUDE_DIR
-        ${CPPDAP_GOOGLETEST_DIR}/googlemock/include/
-        ${CPPDAP_GOOGLETEST_DIR}/googletest/
-        ${CPPDAP_GOOGLETEST_DIR}/googletest/include/
-    )
+    if(CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
+        find_package(GTest REQUIRED)
+    else()
+        list(APPEND DAP_TEST_LIST
+            ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
+        )
+
+        set(DAP_TEST_INCLUDE_DIR
+            ${CPPDAP_GOOGLETEST_DIR}/googlemock/include/
+            ${CPPDAP_GOOGLETEST_DIR}/googletest/
+            ${CPPDAP_GOOGLETEST_DIR}/googletest/include/
+        )
+    endif()
 
     add_executable(cppdap-unittests ${DAP_TEST_LIST})
+    add_test(NAME cppdap-unittests COMMAND cppdap-unittests)
 
     target_include_directories(cppdap-unittests PUBLIC ${DAP_TEST_INCLUDE_DIR} )
     set_target_properties(cppdap-unittests PROPERTIES
@@ -312,7 +323,11 @@ if(CPPDAP_BUILD_TESTS)
     endif()
 
     cppdap_set_target_options(cppdap-unittests)
-    target_link_libraries(cppdap-unittests PRIVATE cppdap)
+    if(CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
+        target_link_libraries(cppdap-unittests PRIVATE cppdap GTest::gtest)
+    else()
+        target_link_libraries(cppdap-unittests PRIVATE cppdap)
+    endif()
 endif(CPPDAP_BUILD_TESTS)
 
 # fuzzer


### PR DESCRIPTION
- Add CPPDAP_USE_EXTERNAL_GTEST_PACKAGE option
- Use `enable_testing()` and `add_test()` so that we can run ctest.

With the `CPPDAP_USE_EXTERNAL_GTEST_PACKAGE` option (ON or OFF), It can successfully build and run the tests.

build log:
<details>

```bash
❯ rm -rf build && cmake . -B build/ -DCPPDAP_USE_EXTERNAL_NLOHMANN_JSON_PACKAGE=ON -DCPPDAP_USE_EXTERNAL_GTEST_P
ACKAGE=ON -DCPPDAP_BUILD_TESTS=ON && cmake --build build/ -j20 && ctest --test-dir build/ -j20
-- The CXX compiler identification is GNU 13.2.1
-- The C compiler identification is GNU 13.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Warning (dev) in CMakeLists.txt:
  A logical block opening on the line

    /home/aurora/fedora-src/cppdap/CMakeLists.txt:63 (if)

  closes on the line

    /home/aurora/fedora-src/cppdap/CMakeLists.txt:69 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.11.2") 
-- Found GTest: /usr/lib64/cmake/GTest/GTestConfig.cmake (found version "1.14.0")  
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/aurora/fedora-src/cppdap/build
[  7%] Building CXX object CMakeFiles/cppdap.dir/src/null_json_serializer.cpp.o
[  7%] Building CXX object CMakeFiles/cppdap.dir/src/nlohmann_json_serializer.cpp.o
[ 10%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_requests.cpp.o
[ 14%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_response.cpp.o
[ 17%] Building CXX object CMakeFiles/cppdap.dir/src/content_stream.cpp.o
[ 21%] Building CXX object CMakeFiles/cppdap.dir/src/session.cpp.o
[ 25%] Building CXX object CMakeFiles/cppdap.dir/src/io.cpp.o
[ 28%] Building CXX object CMakeFiles/cppdap.dir/src/network.cpp.o
[ 35%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_events.cpp.o
[ 35%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_types.cpp.o
[ 39%] Building CXX object CMakeFiles/cppdap.dir/src/typeof.cpp.o
[ 42%] Building CXX object CMakeFiles/cppdap.dir/src/socket.cpp.o
[ 46%] Building CXX object CMakeFiles/cppdap.dir/src/typeinfo.cpp.o
[ 50%] Linking CXX static library libcppdap.a
[ 50%] Built target cppdap
[ 53%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/json_serializer_test.cpp.o
[ 57%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/rwmutex_test.cpp.o
[ 67%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/network_test.cpp.o
[ 67%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/session_test.cpp.o
[ 67%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/any_test.cpp.o
[ 71%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/chan_test.cpp.o
[ 75%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/socket_test.cpp.o
[ 82%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/content_stream_test.cpp.o
[ 82%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/optional_test.cpp.o
[ 85%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/dap_test.cpp.o
[ 89%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/variant_test.cpp.o
[ 92%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/traits_test.cpp.o
[ 96%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/typeinfo_test.cpp.o
[100%] Linking CXX executable cppdap-unittests
[100%] Built target cppdap-unittests
Internal ctest changing into directory: /home/aurora/fedora-src/cppdap/build
Test project /home/aurora/fedora-src/cppdap/build
    Start 1: cppdap-unittests
1/1 Test #1: cppdap-unittests .................   Passed    6.06 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   6.06 sec

aurora in 🌐 fedora in cppdap on  fix via △ v3.27.7 took 6s 
❯ rm -rf build && cmake . -B build/ -DCPPDAP_USE_EXTERNAL_NLOHMANN_JSON_PACKAGE=ON -DCPPDAP_USE_EXTERNAL_GTEST_P
ACKAGE=OFF -DCPPDAP_BUILD_TESTS=ON && cmake --build build/ -j20 && ctest --test-dir build/ -j20
-- The CXX compiler identification is GNU 13.2.1
-- The C compiler identification is GNU 13.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Warning (dev) in CMakeLists.txt:
  A logical block opening on the line

    /home/aurora/fedora-src/cppdap/CMakeLists.txt:63 (if)

  closes on the line

    /home/aurora/fedora-src/cppdap/CMakeLists.txt:69 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.11.2") 
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /home/aurora/fedora-src/cppdap/build
[  3%] Building CXX object CMakeFiles/cppdap.dir/src/null_json_serializer.cpp.o
[ 10%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_requests.cpp.o
[ 10%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_events.cpp.o
[ 13%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_response.cpp.o
[ 17%] Building CXX object CMakeFiles/cppdap.dir/src/session.cpp.o
[ 20%] Building CXX object CMakeFiles/cppdap.dir/src/content_stream.cpp.o
[ 24%] Building CXX object CMakeFiles/cppdap.dir/src/io.cpp.o
[ 27%] Building CXX object CMakeFiles/cppdap.dir/src/nlohmann_json_serializer.cpp.o
[ 31%] Building CXX object CMakeFiles/cppdap.dir/src/socket.cpp.o
[ 34%] Building CXX object CMakeFiles/cppdap.dir/src/network.cpp.o
[ 37%] Building CXX object CMakeFiles/cppdap.dir/src/protocol_types.cpp.o
[ 41%] Building CXX object CMakeFiles/cppdap.dir/src/typeinfo.cpp.o
[ 44%] Building CXX object CMakeFiles/cppdap.dir/src/typeof.cpp.o
[ 48%] Linking CXX static library libcppdap.a
[ 48%] Built target cppdap
[ 55%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/rwmutex_test.cpp.o
[ 55%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/optional_test.cpp.o
[ 58%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/session_test.cpp.o
[ 62%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/typeinfo_test.cpp.o
[ 65%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/network_test.cpp.o
[ 72%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/any_test.cpp.o
[ 75%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/variant_test.cpp.o
[ 72%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/json_serializer_test.cpp.o
[ 79%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/chan_test.cpp.o
[ 86%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/dap_test.cpp.o
[ 86%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/content_stream_test.cpp.o
[ 89%] Building CXX object CMakeFiles/cppdap-unittests.dir/third_party/googletest/googletest/src/gtest-all.cc.o
[ 93%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/socket_test.cpp.o
[ 96%] Building CXX object CMakeFiles/cppdap-unittests.dir/src/traits_test.cpp.o
In file included from /home/aurora/fedora-src/cppdap/third_party/googletest/googletest/src/gtest-all.cc:42:
/home/aurora/fedora-src/cppdap/third_party/googletest/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
/home/aurora/fedora-src/cppdap/third_party/googletest/googletest/src/gtest-death-test.cc:1301:24: warning: ‘dummy’ may be used uninitialized [-Wmaybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/aurora/fedora-src/cppdap/third_party/googletest/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
 1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
/home/aurora/fedora-src/cppdap/third_party/googletest/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
 1299 |   int dummy;
      |       ^~~~~
[100%] Linking CXX executable cppdap-unittests
[100%] Built target cppdap-unittests
Internal ctest changing into directory: /home/aurora/fedora-src/cppdap/build
Test project /home/aurora/fedora-src/cppdap/build
    Start 1: cppdap-unittests
1/1 Test #1: cppdap-unittests .................   Passed    6.05 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   6.05 sec
```

</details>