### PR TITLE
cmake: Fix inconsistent endif() argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(CPPDAP_BUILD_TESTS AND NOT CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
         message(WARNING "Run: `git submodule update --init` to build tests.")
         set(CPPDAP_BUILD_TESTS OFF)
     endif()
-endif(CPPDAP_BUILD_TESTS)
+endif()
 
 ###########################################################
 # JSON library


### PR DESCRIPTION
The argument in the corresponding `if()` was changed in commit ae76a38. CMake emits a warning.
Modern CMake style guides advice on ommitting `endif()` arguments.