### PR TITLE
Add reference in range-for for non-trivial type

### DIFF
--- a/include/dap/typeof.h
+++ b/include/dap/typeof.h
@@ -164,7 +164,7 @@ M member_type(M T::*);
   bool TypeOf<STRUCT>::deserializeFields(const Deserializer* fd, void* obj) { \
     using StructTy = STRUCT;                                                  \
     (void)sizeof(StructTy); /* avoid unused 'using' warning */                \
-    for (auto field : std::initializer_list<Field>{__VA_ARGS__}) {            \
+    for (auto& field : std::initializer_list<Field>{__VA_ARGS__}) {            \
       if (!fd->field(field.name, [&](Deserializer* d) {                       \
             auto ptr = reinterpret_cast<uint8_t*>(obj) + field.offset;        \
             return field.type->deserialize(d, ptr);                           \
@@ -177,7 +177,7 @@ M member_type(M T::*);
   bool TypeOf<STRUCT>::serializeFields(FieldSerializer* fs, const void* obj) {\
     using StructTy = STRUCT;                                                  \
     (void)sizeof(StructTy); /* avoid unused 'using' warning */                \
-    for (auto field : std::initializer_list<Field>{__VA_ARGS__}) {            \
+    for (auto& field : std::initializer_list<Field>{__VA_ARGS__}) {            \
       if (!fs->field(field.name, [&](Serializer* s) {                         \
             auto ptr = reinterpret_cast<const uint8_t*>(obj) + field.offset;  \
             return field.type->serialize(s, ptr);                             \


### PR DESCRIPTION
Avoid copy-ctor and dtor to get called.
Found by Clazy (range-loop-reference)