### PR TITLE
Fix for issue #100 start the server on an address other than "localhost"

### DIFF
--- a/include/dap/network.h
+++ b/include/dap/network.h
@@ -44,10 +44,18 @@ class Server {
   // create() constructs and returns a new Server.
   static std::unique_ptr<Server> create();
 
-  // start() begins listening for connections on the given port.
+  // start() begins listening for connections on localhost and the given port.
   // callback will be called for each connection.
   // onError will be called for any connection errors.
   virtual bool start(int port,
+                     const OnConnect& callback,
+                     const OnError& onError = ignoreErrors) = 0;
+
+  // start() begins listening for connections on the given specific address and port.
+  // callback will be called for each connection.
+  // onError will be called for any connection errors.
+  virtual bool start(const char* address,
+                     int port,
                      const OnConnect& callback,
                      const OnError& onError = ignoreErrors) = 0;
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -32,10 +32,17 @@ class Impl : public dap::net::Server {
   bool start(int port,
              const OnConnect& onConnect,
              const OnError& onError) override {
+    return start("localhost", port, onConnect, onError);
+  }
+
+  bool start(const char* address,
+             int port,
+             const OnConnect& onConnect,
+             const OnError& onError) override {
     std::unique_lock<std::mutex> lock(mutex);
     stopWithLock();
     socket = std::unique_ptr<dap::Socket>(
-        new dap::Socket("localhost", std::to_string(port).c_str()));
+        new dap::Socket(address, std::to_string(port).c_str()));
 
     if (!socket->isOpen()) {
       onError("Failed to open socket");


### PR DESCRIPTION
Let possible to start the server on an address other than "localhost"

Add a new prototype of the function "start" for keeping the API stable