### PR TITLE
include/dap/network.h: add <stdint.h> include for `gcc-15`

### DIFF
--- a/include/dap/network.h
+++ b/include/dap/network.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdint.h>
 
 namespace dap {
 class ReaderWriter;


### PR DESCRIPTION
On `gcc-15` without the include header can't be used as is. I noticed `cmake` build failing as:

    dap/network.h:31:39: error: 'uint32_t' has not been declared
       31 |                                       uint32_t timeoutMillis = 0);
          |                                       ^~~~~~~~

The change adds `uint32_t` declaration via `<stdint.h>`.