### PR TITLE
fix: avoid deadlock when the server fails to start.

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -233,17 +233,20 @@ namespace dap {
 Socket::Socket(const char* address, const char* port)
     : shared(Shared::create(address, port)) {
   if (shared) {
+    bool failed = false;
     shared->lock([&](SOCKET socket, const addrinfo* info) {
       if (bind(socket, info->ai_addr, (int)info->ai_addrlen) != 0) {
-        shared.reset();
+        failed = true;
         return;
       }
 
       if (listen(socket, 0) != 0) {
-        shared.reset();
+        failed = true;
         return;
       }
     });
+    if (failed)
+      shared.reset();
   }
 }
 


### PR DESCRIPTION
Fix #134 