### PR TITLE
update bot tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,18 +298,9 @@ if(CPPDAP_BUILD_TESTS)
     if(CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
         find_package(GTest REQUIRED)
     else()
-        list(APPEND DAP_TEST_LIST
-            ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
-        )
-	set_property(SOURCE
-            ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
-            APPEND PROPERTY COMPILE_OPTIONS -w)
-
-        set(DAP_TEST_INCLUDE_DIR
-            ${CPPDAP_GOOGLETEST_DIR}/googlemock/include/
-            ${CPPDAP_GOOGLETEST_DIR}/googletest/
-            ${CPPDAP_GOOGLETEST_DIR}/googletest/include/
-        )
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+        add_subdirectory(${CPPDAP_GOOGLETEST_DIR})
     endif()
 
     add_executable(cppdap-unittests ${DAP_TEST_LIST})
@@ -329,7 +320,7 @@ if(CPPDAP_BUILD_TESTS)
     if(CPPDAP_USE_EXTERNAL_GTEST_PACKAGE)
         target_link_libraries(cppdap-unittests PRIVATE cppdap GTest::gtest)
     else()
-        target_link_libraries(cppdap-unittests PRIVATE cppdap)
+        target_link_libraries(cppdap-unittests PRIVATE cppdap gtest gmock)
     endif()
 endif(CPPDAP_BUILD_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,9 @@ if(CPPDAP_BUILD_TESTS)
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
         set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
         add_subdirectory(${CPPDAP_GOOGLETEST_DIR})
+        # googletest has -Werror=maybe-uninitialized problem.
+        # Disable all warnings in googletest code.
+        target_compile_options(gtest PRIVATE -w)
     endif()
 
     add_executable(cppdap-unittests ${DAP_TEST_LIST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,9 @@ if(CPPDAP_BUILD_TESTS)
         list(APPEND DAP_TEST_LIST
             ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
         )
+	set_property(SOURCE
+            ${CPPDAP_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
+            APPEND PROPERTY COMPILE_OPTIONS -w)
 
         set(DAP_TEST_INCLUDE_DIR
             ${CPPDAP_GOOGLETEST_DIR}/googlemock/include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,15 +301,16 @@ if(CPPDAP_BUILD_TESTS)
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
         set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
         add_subdirectory(${CPPDAP_GOOGLETEST_DIR})
-        # googletest has -Werror=maybe-uninitialized problem.
+        # googletest has -Werror=maybe-uninitialized problems.
         # Disable all warnings in googletest code.
         target_compile_options(gtest PRIVATE -w)
+        # gmock has -Werror=deprecated-copy problems.
+        target_compile_options(gmock PRIVATE -w)
     endif()
 
     add_executable(cppdap-unittests ${DAP_TEST_LIST})
     add_test(NAME cppdap-unittests COMMAND cppdap-unittests)
 
-    target_include_directories(cppdap-unittests PUBLIC ${DAP_TEST_INCLUDE_DIR} )
     set_target_properties(cppdap-unittests PROPERTIES
         FOLDER "Tests"
     )

--- a/kokoro/ubuntu/presubmit-docker.sh
+++ b/kokoro/ubuntu/presubmit-docker.sh
@@ -28,8 +28,8 @@ git config --global --add safe.directory '*'
 git submodule update --init
 
 if [ "$BUILD_SYSTEM" == "cmake" ]; then
-    using cmake-3.17.2
-    using gcc-9
+    using cmake-3.31.2
+    using gcc-13
 
     mkdir build
     cd build

--- a/kokoro/windows/presubmit.bat
+++ b/kokoro/windows/presubmit.bat
@@ -17,7 +17,7 @@ REM limitations under the License.
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 SET BUILD_ROOT=%cd%
-SET PATH=C:\python36;C:\Program Files\cmake-3.23.1-windows-x86_64\bin;%PATH%
+SET PATH=C:\python312;C:\cmake-3.31.2\bin;%PATH%
 SET SRC=%cd%\github\cppdap
 
 cd %SRC%

--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -8,6 +8,7 @@
             "exclude": [
                 ".clang-format",
                 ".gitattributes",
+                ".github/workflows/main.yml",
                 ".gitignore",
                 ".gitmodules",
                 ".vscode/*.json",


### PR DESCRIPTION
Update to:
- gcc-13 on linux
- cmake 3.31.2 on linux, windows
- python 3.12 on Windows

Turn off warnings in googletest source.  There are some warnings in it that cause compilation failure when using warnings-as-errors