### PR TITLE
kokoro: Add vs2022 configs

### DIFF
--- a/kokoro/windows/msvc-14.14-x64/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-14.14-x64/cmake/presubmit.cfg
@@ -10,7 +10,7 @@ env_vars {
 
 env_vars {
   key: "BUILD_GENERATOR"
-  value: "Visual Studio 15 2017 Win64"
+  value: "Visual Studio 15 2017"
 }
 
 env_vars {

--- a/kokoro/windows/presubmit.bat
+++ b/kokoro/windows/presubmit.bat
@@ -26,7 +26,6 @@ if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 git submodule update --init
 if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 
-SET MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild"
 SET CONFIG=Release
 
 mkdir %SRC%\build
@@ -34,11 +33,11 @@ cd %SRC%\build
 if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 
 IF /I "%BUILD_SYSTEM%"=="cmake" (
-    cmake .. -G "%BUILD_GENERATOR%" "-DCPPDAP_BUILD_TESTS=1" "-DCPPDAP_BUILD_EXAMPLES=1" "-DCPPDAP_WARNINGS_AS_ERRORS=1"
+    cmake .. -G "%BUILD_GENERATOR%" -A %BUILD_TARGET_ARCH% "-DCPPDAP_BUILD_TESTS=1" "-DCPPDAP_BUILD_EXAMPLES=1" "-DCPPDAP_WARNINGS_AS_ERRORS=1"
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    %MSBUILD% /p:Configuration=%CONFIG% cppdap.sln
+    cmake --build . --config %CONFIG%
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    Release\cppdap-unittests.exe
+    %CONFIG%\cppdap-unittests.exe
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 ) ELSE (
     echo "Unknown build system: %BUILD_SYSTEM%"

--- a/kokoro/windows/vs2022-amd64/cmake/presubmit.cfg
+++ b/kokoro/windows/vs2022-amd64/cmake/presubmit.cfg
@@ -10,10 +10,10 @@ env_vars {
 
 env_vars {
   key: "BUILD_GENERATOR"
-  value: "Visual Studio 15 2017"
+  value: "Visual Studio 17 2022"
 }
 
 env_vars {
   key: "BUILD_TARGET_ARCH"
-  value: "Win32"
+  value: "x64"
 }

--- a/kokoro/windows/vs2022-x86/cmake/presubmit.cfg
+++ b/kokoro/windows/vs2022-x86/cmake/presubmit.cfg
@@ -10,7 +10,7 @@ env_vars {
 
 env_vars {
   key: "BUILD_GENERATOR"
-  value: "Visual Studio 15 2017"
+  value: "Visual Studio 17 2022"
 }
 
 env_vars {


### PR DESCRIPTION
Fix msvc-14.4 x86 config to actually configure Win32.

Use cmake --build to build, instead of hardcoding the path to msbuild