### PR TITLE
Fix copyright owner on clang-format-all.sh

### DIFF
--- a/clang-format-all.sh
+++ b/clang-format-all.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 The Marl Authors.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Originally authored by Ben Clayton while employed by Google. Marl is a different project.  Change copyright owner to Google LLC like all the other source files.