### PR TITLE
Github CI: add tests for macos, windows, and sanitizers

### DIFF
--- a/.github/actions/build-cppdap/action.yml
+++ b/.github/actions/build-cppdap/action.yml
@@ -1,0 +1,59 @@
+name: Build cppdap
+description: builds the cppdap project
+inputs:
+  msan:
+    description: 'Enable Memory Sanitizer'
+    required: false
+    default: false
+  tsan:
+    description: 'Enable Thread Sanitizer'
+    required: false
+    default: false
+  asan:
+    description: 'Enable Address Sanitizer'
+    required: false
+    default: false
+  config:
+    description: 'Build configuration'
+    required: false
+    default: "Debug"
+  tests:
+    description: 'Build tests'
+    required: false
+    default: false
+  fuzzer:
+    description: 'Build fuzzer'
+    required: false
+    default: false
+  CXX:
+    description: 'C++ Compiler to use'
+    required: false
+    default: ''
+  CC:
+    description: 'C Compiler to use'
+    required: false
+    default: ''
+  install:
+    description: 'Install the build'
+    required: false
+    default: false
+  install_prefix:
+    description: 'Install prefix'
+    required: false
+    default: 'out/usr/local'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build source
+      shell: bash
+      run: |
+        mkdir -p build
+        cd build
+        CC="${{ inputs.CC }}" CXX="${{ inputs.CXX }}" cmake .. -DCPPDAP_BUILD_TESTS=${{ inputs.tests }} -DCPPDAP_BUILD_FUZZER=${{ inputs.fuzzer }} -DCPPDAP_MSAN=${{ inputs.msan }} -DCPPDAP_TSAN=${{ inputs.tsan }} -DCPPDAP_ASAN=${{ inputs.asan }} -DCMAKE_BUILD_TYPE=${{ inputs.config }}
+        cmake --build . --config ${{ inputs.config }}
+    - name: Install
+      shell: bash
+      if: inputs.install == 'true'
+      run: |
+        cmake --install ./build --config ${{ inputs.config }} --prefix ${{ inputs.install_prefix }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,48 +1,88 @@
+name: Test
 on:
   push:
   pull_request:
 
 jobs:
-  linux:
-    name: ci
-    runs-on: ubuntu-latest
-
-    container:
-      image: ubuntu:22.04
-
+  non-linux-tests:
+    name: ${{ matrix.os.name }} tests ( ${{ matrix.config }} )
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       matrix:
-        include:
-          - CC: gcc
-            CXX: g++
-          - CC: clang
-            CXX: clang++
+        os: [{ name: "MacOS", runner: "macos-latest"}, { name: "Windows", runner: "windows-latest"}]
+        config: ["Debug", "Release"]
+    steps:
 
-    # don't run pull requests from local branches twice
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Build source
+        uses: ./.github/actions/build-cppdap
+        with:
+          config: ${{ matrix.config }}
+          tests: true
+          install: true
 
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure -C ${{ matrix.config }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          # if flags are not empty, append them to the name
+          name: cppdap-${{ matrix.os.name }}-${{ matrix.config }}
+          path: out/usr/local/
+
+  linux-tests:
+    name: Linux tests ( ${{ matrix.config }} ${{ matrix.compiler.CC }} ${{ matrix.sanitizer }} )
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04"] #[ubuntu-22.04, ubuntu-24.04]
+        config: ["Debug", "Release"]
+        compiler: [ {CXX: g++, CC: gcc}, {CXX: clang++, CC: clang} ]
+        sanitizer: ["", "asan", "tsan"]
+        exclude:
+          - config: "Release"
+            sanitizer: "asan"
+          - config: "Release"
+            sanitizer: "tsan"
     env:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Install packages
         run: |
-          apt-get -q -y update
-          apt-get -q -y install build-essential cmake git clang
+          sudo apt-get -q -y update
+          sudo apt-get -q -y install build-essential cmake git clang
 
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
 
       - name: Build source
+        uses: ./.github/actions/build-cppdap
+        with:
+          msan: ${{ contains(matrix.sanitizer, 'msan') }}
+          tsan: ${{ contains(matrix.sanitizer, 'tsan') }}
+          asan: ${{ contains(matrix.sanitizer, 'asan') }}
+          config: ${{ matrix.config }}
+          tests: true
+          fuzzer: false
+          CC: ${{ matrix.compiler.CC }}
+          CXX: ${{ matrix.compiler.CXX }}
+          install: true
+        
+      - name: Run tests
+        shell: bash
         run: |
-          mkdir -p build
           cd build
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake ..
-          cmake --build .
-          DESTDIR=../out cmake --install .
+          ./cppdap-unittests
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cppdap-${{ matrix.CC }}
+          # if flags are not empty, append them to the name
+          name: cppdap-Linux-${{ matrix.compiler.CC }}-${{ matrix.config }}${{ matrix.sanitizer != '' && '-' || '' }}${{ matrix.sanitizer }}
           path: out/usr/local/


### PR DESCRIPTION
This expands the GitHub CI to test macos, windows, and Linux with sanitizers.

I had to split the workflow into linux and non-linux tests because of the limitations of the matrix; we only want to test with sanitizers on Linux, and manually excluding them from windows and mac would add a bunch of complexity.