### PR TITLE
Fix deadlock when failing to bind/listen on port

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -233,17 +233,20 @@ namespace dap {
 Socket::Socket(const char* address, const char* port)
     : shared(Shared::create(address, port)) {
   if (shared) {
+    bool reset = false;
     shared->lock([&](SOCKET socket, const addrinfo* info) {
       if (bind(socket, info->ai_addr, (int)info->ai_addrlen) != 0) {
-        shared.reset();
+        reset = true;
         return;
       }
 
       if (listen(socket, 0) != 0) {
-        shared.reset();
-        return;
+        reset = true;
       }
     });
+    if (reset) {
+      shared.reset();
+    }
   }
 }
 


### PR DESCRIPTION
`Socket` deadlocks when failing to bind to a port, due to `reset()` (which calls the `Shared` destructor, which calls its lock) being called while we hold the lock (it would have segfaulted anyway even if this wasn't the case, since the destructor would have been called while we were in the middle of a member call stack). Calling `reset()` while outside of the lock fixes this.