### PR TITLE
any: rename `free()` to `freeValue()`

### DIFF
--- a/include/dap/any.h
+++ b/include/dap/any.h
@@ -67,7 +67,7 @@ class any {
 
   static inline void* alignUp(void* val, size_t alignment);
   inline void alloc(size_t size, size_t align);
-  inline void free();
+  inline void freeValue();
   inline bool isInBuffer(void* ptr) const;
 
   void* value = nullptr;
@@ -106,7 +106,7 @@ any::any(any&& other) noexcept : type(other.type) {
 void any::reset() {
   if (value != nullptr) {
     type->destruct(value);
-    free();
+    freeValue();
   }
   value = nullptr;
   type = nullptr;
@@ -191,7 +191,7 @@ void any::alloc(size_t size, size_t align) {
   value = alignUp(heap, align);
 }
 
-void any::free() {
+void any::freeValue() {
   assert(value != nullptr);
   if (heap != nullptr) {
     delete[] reinterpret_cast<uint8_t*>(heap);


### PR DESCRIPTION
Many C++ projects have their own memory management systems. This is especially the case for games (which often have their own scripting system, which would like to make use of a DAP library to debug them). Often times these games will redefine `free` via a macro to invoke their own memory mangement functions. If `free()` gets defined as a macro, attempting to compile `any.h` will cause the compiler to explode.

I note that this is a private function that is only used within `any.h` and it's only used twice, so this should not create any API compatibility issues.