### PR TITLE
Fix the issue where terminated events cannot be handled.

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -30,6 +30,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <set>
 
 namespace {
 
@@ -410,7 +411,9 @@ class Impl : public dap::Session {
     // "body" is an optional field for some events, such as "Terminated Event".
     bool body_ok = true;
     d->field("body", [&](dap::Deserializer* d) {
-      if (!typeinfo->deserialize(d, data)) {
+      // todo: to completed event list
+      std::set<std::string> bodyCanBeEmpty { "terminated" };
+      if (!typeinfo->deserialize(d, data) && bodyCanBeEmpty.find(event) == bodyCanBeEmpty.end()) {
         body_ok = false;
       }
       return true;


### PR DESCRIPTION
When debugging Python applications via cppdap and debugpy, after the application finishes running, the following request {... body:{} ...} is sent. cppdap incorrectly processes it—the body field is optional and can be empty. However, cppdap treats it as an error and throws an exception, which is unreasonable.

issue: https://github.com/google/cppdap/issues/152