### PR TITLE
Add initial bazel build

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+third_party/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,136 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+cc_library(
+    name = "api",
+    hdrs = glob(["include/dap/*.h"]),
+    strip_include_prefix = "include",
+)
+
+cc_library(
+    name = "null_json_serializer",
+    srcs = ["src/null_json_serializer.cpp"],
+    hdrs = ["src/null_json_serializer.h"],
+    deps = [":api"],
+)
+
+cc_library(
+    name = "jsoncpp_json_serializer",
+    srcs = ["src/jsoncpp_json_serializer.cpp"],
+    hdrs = ["src/jsoncpp_json_serializer.h"],
+    deps = [
+        ":api",
+        ":null_json_serializer",
+        "@jsoncpp",
+    ],
+)
+
+cc_library(
+    name = "nlohmann_json_serializer",
+    srcs = ["src/nlohmann_json_serializer.cpp"],
+    hdrs = ["src/nlohmann_json_serializer.h"],
+    deps = [
+        ":api",
+        ":null_json_serializer",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_library(
+    name = "rapid_json_serializer",
+    srcs = ["src/rapid_json_serializer.cpp"],
+    hdrs = ["src/rapid_json_serializer.h"],
+    deps = [
+        ":api",
+        ":null_json_serializer",
+        "@rapidjson",
+    ],
+)
+
+cc_library(
+    name = "json_serializer",
+    hdrs = ["src/json_serializer.h"],
+    defines = select(
+        {
+            ":nlohmann_json": ["CPPDAP_JSON_NLOHMANN"],
+            ":jsoncpp_json": ["CPPDAP_JSON_JSONCPP"],
+            ":rapid_json": ["CPPDAP_JSON_RAPID"],
+        },
+        no_match_error = "Invalid json serializer selection",
+    ),
+    deps = select(
+        {
+            ":nlohmann_json": [":nlohmann_json_serializer"],
+            ":jsoncpp_json": [":jsoncpp_json_serializer"],
+            ":rapid_json": [":rapid_json_serializer"],
+        },
+        no_match_error = "Invalid json serializer selection",
+    ),
+)
+
+string_flag(
+    name = "json",
+    build_setting_default = "nlohmann",
+    values = [
+        "nlohmann",
+        "jsoncpp",
+        "rapid",
+    ],
+)
+
+config_setting(
+    name = "nlohmann_json",
+    flag_values = {":json": "nlohmann"},
+)
+
+config_setting(
+    name = "jsoncpp_json",
+    flag_values = {":json": "jsoncpp"},
+)
+
+config_setting(
+    name = "rapid_json",
+    flag_values = {":json": "rapid"},
+)
+
+cc_library(
+    name = "cppdap",
+    srcs = glob(
+        [
+            "src/*.cpp",
+            "src/*.h",
+        ],
+        exclude = [
+            "src/*test.*",
+            "src/*json_serializer.*",
+        ],
+    ),
+    deps = [
+        ":api",
+        ":json_serializer",
+    ],
+)
+
+TESTS = [
+    "any",
+    "chan",
+    "content_stream",
+    "dap",
+    "json_serializer",
+    "network",
+    "optional",
+    "rwmutex",
+    "session",
+    "socket",
+    "traits",
+    "typeinfo",
+    "variant",
+]
+
+[
+    cc_test(
+        name = test_name + "_test",
+        srcs = ["src/" + test_name + "_test.cpp"],
+        deps = [":cppdap", "@googletest//:gtest_main"],
+    )
+    for test_name in TESTS
+]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,13 @@
+module(name="cppdap", version="1.65.0")
+
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+
+# Test with diffrent json libraries (inside cppdap, you can omit '@cppdap')
+#   bazel test --//@cppdap:json=nlohmann ...
+#   bazel test --//@cppdap:json=jsoncpp ...
+#   bazel test --//@cppdap:json=rapid ...
+bazel_dep(name = "nlohmann_json", version = "3.12.0")
+bazel_dep(name = "jsoncpp", version = "1.9.6")
+bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20241007")
+
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)


### PR DESCRIPTION
This  adds basic bazel support

No fuzzing, or sanitizers yet, but the ability to select `json` library and all other `tests` are in.

```sh
bazel test -k ...
```

This would select the `nlohmann` json library. To select another, for example `rapid` json, use this:

```sh
bazel test -k --//:json=rapid ...
```

The other options are: `jsoncpp` and  `nlohmann` (the default)

When used as module dependency, you should fully qualify - e.g. `--//@cppdap:json=<library>`

```sh
common --//@cppdap:json=rapid
```

Place above in your `.bazelrc` file, and it'll set `rapid` json as the default choice.
